### PR TITLE
chore: release v0.1.0

### DIFF
--- a/client/CHANGELOG.md
+++ b/client/CHANGELOG.md
@@ -15,6 +15,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - fix small bug
 
 ### Other
+- release ([#6](https://github.com/horfimbor/horfimbor-template/pull/6))
+- update dependencies
+- add reconnect
+- handle endpoint from server
+- upgrade from hfb-galaxy startup
+- Add delay ([#1](https://github.com/horfimbor/horfimbor-template/pull/1))
+- remove unwrap from frontend
+- handle message in yew
+- add sse server and client
+- handle change on gyg-eventsource
+- add template tera
+- use redis for dto and state + create frontend with Yew
+- add Yew as web component
+- allow to load template-shared from the client
+- add dto beside state
+- add tests with cucumber
+- create shared command and events
+
+## [0.1.0](https://github.com/horfimbor/horfimbor-template/releases/tag/template-client-v0.1.0) - 2024-08-29
+
+### Fixed
+- fix : upgrade eventsource
+- naming ([#3](https://github.com/horfimbor/horfimbor-template/pull/3))
+- fix clippy
+- fix small bug
+
+### Other
 - update dependencies
 - add reconnect
 - handle endpoint from server

--- a/consumer/CHANGELOG.md
+++ b/consumer/CHANGELOG.md
@@ -13,6 +13,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - naming ([#3](https://github.com/horfimbor/horfimbor-template/pull/3))
 
 ### Other
+- release ([#6](https://github.com/horfimbor/horfimbor-template/pull/6))
+- update horfimbor-engine to 0.3 ([#4](https://github.com/horfimbor/horfimbor-template/pull/4))
+- upgrade from hfb-galaxy startup
+- use new linter
+- Add delay ([#1](https://github.com/horfimbor/horfimbor-template/pull/1))
+
+## [0.1.0](https://github.com/horfimbor/horfimbor-template/releases/tag/template-consumer-v0.1.0) - 2024-08-29
+
+### Fixed
+- fix : upgrade eventsource
+- naming ([#3](https://github.com/horfimbor/horfimbor-template/pull/3))
+
+### Other
 - update horfimbor-engine to 0.3 ([#4](https://github.com/horfimbor/horfimbor-template/pull/4))
 - upgrade from hfb-galaxy startup
 - use new linter

--- a/server/CHANGELOG.md
+++ b/server/CHANGELOG.md
@@ -14,6 +14,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - fix clippy
 
 ### Other
+- release ([#6](https://github.com/horfimbor/horfimbor-template/pull/6))
+- update horfimbor-engine to 0.3 ([#4](https://github.com/horfimbor/horfimbor-template/pull/4))
+- handle endpoint from server
+- upgrade from hfb-galaxy startup
+- use new linter
+- Add delay ([#1](https://github.com/horfimbor/horfimbor-template/pull/1))
+- remove unwrap from sse
+- remove unwrap from frontend
+- handle message in yew
+- add sse server and client
+- handle change on gyg-eventsource
+- add template tera
+- use dto from cache
+- use redis for dto and state + create frontend with Yew
+- add Yew as web component
+- allow to load template-shared from the client
+- add dto beside state
+- add controllers
+- add rocket server
+- add tests with cucumber
+- create shared command and events
+
+## [0.1.0](https://github.com/horfimbor/horfimbor-template/releases/tag/template-server-v0.1.0) - 2024-08-29
+
+### Fixed
+- fix : upgrade eventsource
+- naming ([#3](https://github.com/horfimbor/horfimbor-template/pull/3))
+- fix clippy
+
+### Other
 - update horfimbor-engine to 0.3 ([#4](https://github.com/horfimbor/horfimbor-template/pull/4))
 - handle endpoint from server
 - upgrade from hfb-galaxy startup

--- a/shared/CHANGELOG.md
+++ b/shared/CHANGELOG.md
@@ -14,6 +14,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - fix small bug
 
 ### Other
+- release ([#6](https://github.com/horfimbor/horfimbor-template/pull/6))
+- update horfimbor-engine to 0.3 ([#4](https://github.com/horfimbor/horfimbor-template/pull/4))
+- update dependencies
+- upgrade from hfb-galaxy startup
+- use new linter
+- Add delay ([#1](https://github.com/horfimbor/horfimbor-template/pull/1))
+- add template tera
+- use redis for dto and state + create frontend with Yew
+- add Yew as web component
+- allow to load template-shared from the client
+- add dto beside state
+- add controllers
+- add tests with cucumber
+- create shared command and events
+
+## [0.1.0](https://github.com/horfimbor/horfimbor-template/releases/tag/template-shared-v0.1.0) - 2024-08-29
+
+### Fixed
+- fix : upgrade eventsource
+- naming ([#3](https://github.com/horfimbor/horfimbor-template/pull/3))
+- fix small bug
+
+### Other
 - update horfimbor-engine to 0.3 ([#4](https://github.com/horfimbor/horfimbor-template/pull/4))
 - update dependencies
 - upgrade from hfb-galaxy startup

--- a/state/CHANGELOG.md
+++ b/state/CHANGELOG.md
@@ -13,6 +13,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - naming ([#3](https://github.com/horfimbor/horfimbor-template/pull/3))
 
 ### Other
+- release ([#6](https://github.com/horfimbor/horfimbor-template/pull/6))
+- update horfimbor-engine to 0.3 ([#4](https://github.com/horfimbor/horfimbor-template/pull/4))
+- upgrade from hfb-galaxy startup
+- use new linter
+- Add delay ([#1](https://github.com/horfimbor/horfimbor-template/pull/1))
+- allow to load template-shared from the client
+- add dto beside state
+- add controllers
+- add tests with cucumber
+- create shared command and events
+
+## [0.1.0](https://github.com/horfimbor/horfimbor-template/releases/tag/template-state-v0.1.0) - 2024-08-29
+
+### Fixed
+- fix : upgrade eventsource
+- naming ([#3](https://github.com/horfimbor/horfimbor-template/pull/3))
+
+### Other
 - update horfimbor-engine to 0.3 ([#4](https://github.com/horfimbor/horfimbor-template/pull/4))
 - upgrade from hfb-galaxy startup
 - use new linter


### PR DESCRIPTION
## 🤖 New release
* `template-client`: 0.1.0
* `template-shared`: 0.1.0
* `template-consumer`: 0.1.0
* `template-state`: 0.1.0
* `template-server`: 0.1.0

<details><summary><i><b>Changelog</b></i></summary><p>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).